### PR TITLE
Add Danish translation

### DIFF
--- a/src/js/i18n/datepicker.da.js
+++ b/src/js/i18n/datepicker.da.js
@@ -1,0 +1,11 @@
+Datepicker.language['da'] = {
+    days: ['Søndag', 'Mandag', 'Tirsdag', 'Onsdag', 'Torsdag', 'Fredag', 'Lørdag'],
+    daysShort: ['Søn', 'Man', 'Tir', 'Ons', 'Tor', 'Fre', 'Lør'],
+    daysMin: ['Sø', 'Ma', 'Ti', 'On', 'To', 'Fr', 'Lø'],
+    months: ['Januar','Februar','Marts','April','Maj','Juni', 'Juli','August','September','Oktober','November','December'],
+    monthsShort: ['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
+    today: 'I dag',
+    clear: 'Nulstil',
+    dateFormat: 'dd/mm/yyyy',
+    firstDay: 0
+};

--- a/src/js/i18n/datepicker.da.js
+++ b/src/js/i18n/datepicker.da.js
@@ -7,5 +7,5 @@ Datepicker.language['da'] = {
     today: 'I dag',
     clear: 'Nulstil',
     dateFormat: 'dd/mm/yyyy',
-    firstDay: 0
+    firstDay: 1
 };


### PR DESCRIPTION
Added Danish translation of the dates.

Furthermore I think all language by default should display year in format `yyyy`, e.g. for English.
https://github.com/t1m0n/air-datepicker/blob/master/src/js/i18n/datepicker.en.js#L9

and maybe set language to English as default?