### PR TITLE
Correct dateFormat and firstDay for nl i18n

### DIFF
--- a/src/js/i18n/datepicker.nl.js
+++ b/src/js/i18n/datepicker.nl.js
@@ -6,7 +6,7 @@ $.fn.datepicker.language['nl'] = {
     monthsShort: ['Jan', 'Feb', 'Mrt', 'Apr', 'Mei', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec'],
     today: 'Vandaag',
     clear: 'Legen',
-    dateFormat: 'dd-MM-yy',
+    dateFormat: 'dd-mm-yyyy',
     timeFormat: 'hh:ii',
-    firstDay: 0
+    firstDay: 1
 };


### PR DESCRIPTION
The first day of the week should be a Monday in the Netherlands. This is also the case with [jQuery UI's datepicker](https://github.com/jquery/jquery-ui/blob/master/ui/i18n/datepicker-nl.js)

Also, the dateFormat is incorrectly set. Have modified this to use the same format as English, but in the correct order for NL: day-month-year