### PR TITLE
Added italian translation

### DIFF
--- a/src/js/i18n/datepicker.it.js
+++ b/src/js/i18n/datepicker.it.js
@@ -1,0 +1,12 @@
+;(function ($) { $.fn.datepicker.language['it'] = {
+    days: ['Domenica', 'Lunedì', 'Martedì', 'Mercoledì', 'Giovedì', 'Venerdì', 'Sabato'],
+    daysShort: ['Dom', 'Lun', 'Mar', 'Mer', 'Gio', 'Ven', 'Sab'],
+    daysMin: ['Do', 'Lu', 'Ma', 'Me', 'Gi', 'Ve', 'Sa'],
+    months: ['Gennaio','Febbraio','Marzo','Aprile','Maggio','Giugno', 'Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'],
+    monthsShort: ['Gen', 'Feb', 'Mar', 'Apr', 'Mag', 'Giu', 'Lug', 'Ago', 'Set', 'Ott', 'Nov', 'Dic'],
+    today: 'Oggi',
+    clear: 'Pulisci',
+    dateFormat: 'dd/mm/yyyy',
+    timeFormat: 'hh:ii',
+    firstDay: 1
+}; })(jQuery);


### PR DESCRIPTION
Added italian translation under src/js/i18n/datepicker.it.js.
First day of week is Monday, dateFormat is `dd/mm/yyyy` and timeFormat is `hh:ii`.
I wasn't sure when translating `Clear` but I think that `Pulisci` should be fine.