### PR TITLE
Fix selectDate

### DIFF
--- a/dist/js/datepicker.js
+++ b/dist/js/datepicker.js
@@ -480,9 +480,9 @@
             }
 
             if (_this.view == 'days') {
-                if (date.getMonth() != d.month && opts.moveToOtherMonthsOnSelect) {
+                //if (date.getMonth() != d.month && opts.moveToOtherMonthsOnSelect) {
                     newDate = new Date(date.getFullYear(), date.getMonth(), 1);
-                }
+                //}
             }
 
             if (_this.view == 'years') {


### PR DESCRIPTION
selectDate не перерисовывает если переданная дата была в том же месяце год и более назад
Есть такой календарь:
$('#start-date').datepicker();
попробуем выбрать дату:
`$('#start-date').data('datepicker').selectDate(new Date(2017,1,1));`
работает - в календаре выделено 1 февраля 2017, календарь на феврале 2017
`$('#start-date').data('datepicker').selectDate(new Date(2017,0,1));`
не работает. в календаре есть подсветка 1 января 2017, но календарь на январе 2018, чтобы добраться до выбранной  даты нужно пролистать календарь.

в коде есть условие 
`
if (_this.view == 'days') {
                if (date.getMonth() != d.month &&  date.getFullYear() != d.year && opts.moveToOtherMonthsOnSelect) {
                    newDate = new Date(date.getFullYear(), date.getMonth(), 1);
                }
            }
`
из-за него newDate не выставляется в нужное значение и ниже не вызывается _this.nav._render()
проблема в date.getMonth() != d.month, получается календарь не будет перерисовываться, если месяц любого года совпадает.

Решение не совсем правильное, потому что там есть еще опция moveToOtherMonthsOnSelect, но пока я у себя просто закоментировал это условие.