### PR TITLE
Added ability for appending to custom containers and modals

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ $('.my-datepicker').datepicker([options])
 
 ## Change log
 
+### v2.3.0
+* added appending the datepicker to custom containers or modals. Can be used as this:
+  $(this.dateInput.nativeElement).datepicker({
+        startDate: someDate,
+        minDate: someDate,
+        appendById: 'yourId', //appendByClass: 'yourClass'
+
 ### v2.2.3
 * fixed min,max dates in decade mode
 

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ $('.my-datepicker').datepicker([options])
 
 ### v2.3.0
 * added appending the datepicker to custom containers or modals. Can be used as this:
+```javascript
   $(this.dateInput.nativeElement).datepicker({
         startDate: someDate,
         minDate: someDate,
-        appendById: 'yourId', //appendByClass: 'yourClass'
+        appendById: 'yourId' //appendByClass: 'yourClass'
+   });
+ ```
 
 ### v2.2.3
 * fixed min,max dates in decade mode

--- a/src/js/datepicker.js
+++ b/src/js/datepicker.js
@@ -4,6 +4,7 @@
         autoInitSelector = '.datepicker-here',
         $body, $datepickersContainer,
         containerBuilt = false,
+        isCustomAppend = false,
         baseTemplate = '' +
             '<div class="datepicker">' +
             '<i class="datepicker--pointer"></i>' +
@@ -106,7 +107,15 @@
 
         this.opts = $.extend(true, {}, defaults, options, this.$el.data());
 
-        if ($body == undefined) {
+        if (this.opts.appendById) {
+            $body = $('#' + this.opts.appendById);
+            isCustomAppend = true;
+        }
+        else if (this.opts.appendByClass) {
+            $body = $('.' + this.opts.appendByClass);
+            isCustomAppend = true;
+        }
+        else {
             $body = $('body');
         }
 
@@ -262,8 +271,14 @@
 
         _buildDatepickersContainer: function () {
             containerBuilt = true;
-            $body.append('<div class="datepickers-container" id="datepickers-container"></div>');
-            $datepickersContainer = $('#datepickers-container');
+            if (isCustomAppend) {
+                var customId = this.opts.appendById || this.opts.appendByClass;
+                $body.append('<div class="datepickers-container" id="datepickers-container-' + customId + '"></div>');
+                $datepickersContainer = $('#datepickers-container-' + customId);
+            } else {
+                $body.append('<div class="datepickers-container" id="datepickers-container"></div>');
+                $datepickersContainer = $('#datepickers-container');
+            }
         },
 
         _buildBaseHtml: function () {
@@ -723,12 +738,14 @@
 
         _getDimensions: function ($el) {
             var offset = $el.offset();
+            var customOffsetLeft = $el.offset().left - $body.offset().left;
+            var customOffsetTop = $el.offset().top - $body.offset().top;
 
             return {
                 width: $el.outerWidth(),
                 height: $el.outerHeight(),
-                left: offset.left,
-                top: offset.top
+                left: isCustomAppend ? customOffsetLeft : offset.left,
+                top: isCustomAppend ? customOffsetTop : offset.top
             }
         },
 

--- a/src/js/datepicker.js
+++ b/src/js/datepicker.js
@@ -1,5 +1,5 @@
 ;(function () {
-    var VERSION = '2.2.3',
+    var VERSION = '2.3.0',
         pluginName = 'datepicker',
         autoInitSelector = '.datepicker-here',
         $body, $datepickersContainer,


### PR DESCRIPTION
These changes allow you to bind datepicker to some custom containers or modals by using 'appendById' or 'appendByClass' option in element initializing.