### PR TITLE
Prevent crash when use lib inside webcomponent

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -291,9 +291,7 @@ export function addEventListener(el, type, listener) {
  * @return {HTMLElement|Boolean}
  */
 export function closest(target, selector) {
-    if (!target || target === document) return false;
-
-    if (typeof target.matches !== 'function') return false;
+    if (!target || target === document ||  target instanceof DocumentFragment) return false;
 
     if (target.matches(selector)) {
         return target;

--- a/src/utils.js
+++ b/src/utils.js
@@ -293,6 +293,8 @@ export function addEventListener(el, type, listener) {
 export function closest(target, selector) {
     if (!target || target === document) return false;
 
+    if (typeof target.matches !== 'function') return false;
+
     if (target.matches(selector)) {
         return target;
     }


### PR DESCRIPTION
I'm using this lib inside Stencil webcomponent with shadow dom activated. The problem is when the closest funtion is trying to find a document element because inside shadowDorm we have not a document element, we have a document-fragment element without matches function so for that i added an if to return false in that case because we able to asume that is the last parent or cant continue finding more nodes.