### PR TITLE
Feature button attributes

### DIFF
--- a/src/datepickerButtons.js
+++ b/src/datepickerButtons.js
@@ -64,15 +64,17 @@ export default class DatepickerButtons {
      * @param {String|Function} content - button content
      * @param {String} [className]
      * @param {String} [tagName=button]
+     * @param {Object} [attrs]
      * @return HTMLElement
      */
-    createButton({content, className, tagName='button'}){
+    createButton({content, className, tagName='button', attrs={}}){
         let _content = typeof content === 'function' ? content(this.dp) : content;
 
         return createElement({
             tagName,
             innerHtml: `<span tabindex='-1'>${_content}</span>`,
             className: classNames('air-datepicker-button', className)
+            attrs
         });
     }
 

--- a/src/datepickerButtons.js
+++ b/src/datepickerButtons.js
@@ -73,7 +73,7 @@ export default class DatepickerButtons {
         return createElement({
             tagName,
             innerHtml: `<span tabindex='-1'>${_content}</span>`,
-            className: classNames('air-datepicker-button', className)
+            className: classNames('air-datepicker-button', className),
             attrs
         });
     }


### PR DESCRIPTION
When I was creating a custom button, I ran into a problem that I couldn't hang my attributes - my datapicker is inside the form, and when I click on "clear", my form is sent to the server and a reboot occurs (which I don't need), because there is no type="button" attribute

I think this pull request can solve my problem