### PR TITLE
feat: The bindEvents function has been modified for CordovaJS compati…

### DIFF
--- a/src/datepickerBody.js
+++ b/src/datepickerBody.js
@@ -51,15 +51,15 @@ export default class DatepickerBody {
     _bindEvents() {
         let {range, dynamicRange} = this.opts;
 
-        addEventListener(this.$el, 'mouseover', this.onMouseOverCell);
-        addEventListener(this.$el, 'mouseout', this.onMouseOutCell);
-        addEventListener(this.$el, 'click', this.onClickBody);
+        this.$el.addEventListener('mouseover', this.onMouseOverCell);
+        this.$el.addEventListener('mouseout', this.onMouseOutCell);
+        this.$el.addEventListener('click', this.onClickBody);
 
 
         if (range && dynamicRange) {
-            addEventListener(this.$el, 'mousedown', this.onMouseDown);
-            addEventListener(this.$el, 'mousemove', this.onMouseMove);
-            addEventListener(window.document, 'mouseup', this.onMouseUp);
+            this.$el.addEventListener('mousedown', this.onMouseDown);
+            this.$el.addEventListener('mousemove', this.onMouseMove);
+            window.document.addEventListener('mouseup', this.onMouseUp);
         }
 
     }


### PR DESCRIPTION
The bindEvents function in the datepickerBody file has been modified to be compatible with CordovaJS, since the way events were being bound Cordova did not accept it.
<img width="1520" alt="Captura de Pantalla 2022-09-05 a la(s) 10 14 22 a m" src="https://user-images.githubusercontent.com/54912992/188479939-3671e364-995f-40cb-bcf0-e38654158f2a.png">
<img width="1039" alt="Captura de Pantalla 2022-09-05 a la(s) 10 15 11 a m" src="https://user-images.githubusercontent.com/54912992/188480023-514428b5-4907-4362-bc80-35ce76d0429f.png">
<img width="1488" alt="Captura de Pantalla 2022-09-05 a la(s) 10 20 11 a m" src="https://user-images.githubusercontent.com/54912992/188480429-d8d6adbf-fcd1-4f63-a82e-2d37aaadb151.png">
