### PR TITLE
Update slider track colour

### DIFF
--- a/src/sass/timepicker.scss
+++ b/src/sass/timepicker.scss
@@ -53,7 +53,7 @@ $rangeThumbBg: #dedede;
   border: none;
   height: $rangeTrackHeight;
   cursor: pointer;
-  color: transparent;
+  color: black;
   background: transparent;
 }
 


### PR DESCRIPTION
Changed the track colour of the time picker slider to 'black' from 'transparent' as it is unclear what the slider buttons do if the track or its background is transparent.  Users may not realize they are sliders, confusing them to be random tick boxes