### PR TITLE
fixed German translation for "clear"

### DIFF
--- a/src/locale/de.js
+++ b/src/locale/de.js
@@ -5,7 +5,7 @@ export default {
     months: ['Januar', 'Februar', 'März', 'April', 'Mai', 'Juni', 'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember'],
     monthsShort: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
     today: 'Heute',
-    clear: 'Aufräumen',
+    clear: 'Löschen',
     dateFormat: 'dd.MM.yyyy',
     timeFormat: 'HH:mm',
     firstDay: 1


### PR DESCRIPTION
In German, the word `Aufräumen` means like cleaning your room and makes almost no sense to me in that context.
`Löschen` (to "delete" the date) makes more sense in my opinion.