### PR TITLE
prevent datepicker from closing when range=true and only one date was selected

### DIFF
--- a/index-dev.js
+++ b/index-dev.js
@@ -27,7 +27,7 @@ let opts = {
     isMobile: false,
     // timepicker: true,
     autoClose: false,
-    range: false,
+    range: true,
     toggleSelected: false,
     // position: customPosition,
     // position: 'right center',
@@ -38,7 +38,7 @@ let opts = {
         // console.log(dp1.getCell('2021-01-01', 'month'))
     },
 
-    selectedDates: [new Date()],
+    selectedDates: [new Date(), new Date("2024-02-30")],
     onSelect({date, formattedDate, datepicker}) {
         selected = true;
         console.log('on select');

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -658,6 +658,12 @@ export default class Datepicker {
     }
 
     hide() {
+        //guard clause to force user to actually select a range of dates instead of just exiting the datepicker
+        let {range} = this.opts;
+        if (range === true) {
+            if (this.selectedDates.length <= 1) return;
+        }
+
         let {onHide, isMobile} = this.opts;
         let hasTransition = this._hasTransition();
 


### PR DESCRIPTION
When using a range input it was possible for the user to only select one date and then exit the picker by clicking outside it. This created a case where only a single date was selected with the second still being undefined. Neither toggleSelected nor specifying pre selected dates would fix this.

You might want to put this behind another option like forceRangeSelection but i dont see why anyone would want the behaviour mentioned above.