### PR TITLE
Fix bug with keyboard navigation

### DIFF
--- a/src/datepickerKeyboard.js
+++ b/src/datepickerKeyboard.js
@@ -25,6 +25,7 @@ export default class DatepickerKeyboard {
 
     init() {
         this.bindKeyboardEvents();
+        this.bindInputBlurEvent();
     }
 
     bindKeyboardEvents() {
@@ -34,11 +35,18 @@ export default class DatepickerKeyboard {
         $el.addEventListener('keyup', this.onKeyUp);
     }
 
+    bindInputBlurEvent() {
+        let {$el} = this.dp;
+
+        $el.addEventListener('blur', this.onInputBlur);
+    }
+
     destroy() {
         let {$el} = this.dp;
 
         $el.removeEventListener('keydown', this.onKeyDown);
         $el.removeEventListener('keyup', this.onKeyUp);
+        $el.removeEventListener('blur', this.onInputBlur);
         this.hotKeys = null;
         this.pressedKeys = null;
     }
@@ -199,5 +207,9 @@ export default class DatepickerKeyboard {
 
     onKeyUp = (e) => {
         this.removeKey(e.key);
+    }
+
+    onInputBlur = () => {
+        this.pressedKeys.clear();
     }
 }


### PR DESCRIPTION
This PR fixes the bug in datepicker keyboard navigation.

The sandbox link: https://codesandbox.io/p/sandbox/sweet-pine-pwmcnk

Steps to reproduce:
1. Set focus into the datepicker input.
2. Navigate to previous focusable element with "shift + tab".
3. Return focus to the input.
4. Try to use arrows to navigate between cells. The datepicker will change years instead of navigating between cells.

The reason of described behaviour is that the "shift" key still in the `pressedKeys` set when datepicker input loses focus (by pressing shift+tab) because the `keyup` event with "shift" key will be fired after the input will lose the focus and `onKeyUp` input handler will be not fired.

The solution:

1. Add blur event listener on input on keyboard navigation initialization.
2. Input blur event handler will clear the `pressedKeys` set.