### PR TITLE
Fix month and minutes being same in Norwegian locale.

### DIFF
--- a/src/locale/nb.js
+++ b/src/locale/nb.js
@@ -6,7 +6,7 @@ export default {
     monthsShort: ["Jan", "Feb", "Mar", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Des"],
     today: "Idag",
     clear: "Fjern",
-    dateFormat: "dd.mm.yyyy",
+    dateFormat: "dd.MM.yyyy",
     timeFormat: "HH:mm",
     firstDay: 1
 };


### PR DESCRIPTION
The month in dateFormat and minute in timeFormat is identical, which makes the datepicker use the minute in the time picker as month in the date format. By changing "mm" to "MM" in dateFormat (like the other locales), will correct that behavior.