### PR TITLE
Add center positions to AirDatepickerPosition type

### DIFF
--- a/dist/air-datepicker.d.ts
+++ b/dist/air-datepicker.d.ts
@@ -23,7 +23,7 @@ export declare type AirDatepickerButton = {
 
 export declare type AirDatepickerButtonPresets = 'clear' | 'today';
 
-export declare type AirDatepickerPosition = 'left' | 'left top' | 'left bottom' | 'top' | 'top left' | 'top right' | 'right' | 'right top' | 'right bottom' | 'bottom' | 'bottom left' | 'bottom right';
+export declare type AirDatepickerPosition = 'left' | 'left top' | 'left center' | 'left bottom' | 'top' | 'top left' | 'top center' | 'top right' | 'right' | 'right top' | 'right center' | 'right bottom' | 'bottom' | 'bottom left' | 'bottom center' | 'bottom right';
 export declare type AirDatepickerViews = 'days' | 'months' | 'years';
 export declare type AirDatepickerViewsSingle = 'day' | 'month' | 'year';
 export declare type AirDatepickerDate = string | number | Date;


### PR DESCRIPTION
Add center positions to AirDatepickerPosition type: `left center`, `top center`, `right center` and `bottom center`.

All those positions are valid and exist in the CSS: https://github.com/olivier-thatch/air-datepicker/blob/olivier-add-center-positions/src/datepicker.scss#L129-L170