### PR TITLE
docs: set correct return type to selectDate fn

### DIFF
--- a/src/datepicker.d.ts
+++ b/src/datepicker.d.ts
@@ -127,7 +127,17 @@ declare class AirDatepicker<E extends HTMLElement = HTMLInputElement> {
     hide: () => void
     next: () => void
     prev: () => void
-    selectDate: (date: AirDatepickerDate | AirDatepickerDate[], opts?: {updateTime?: boolean, silent?: boolean}) => void
+
+    /**
+     * Selects date, if array is passed then selects dates one by one
+     * @param {DateLike|Array<DateLike>} date
+     * @param {object} [opts] - extra parameters
+     * @param {boolean} [opts.updateTime] - should update timepicker's time from passed date
+     * @param {boolean} [opts.silent] - if true, then onChange event wont be triggered
+     * @return {Promise<void>} - returns promise, since input value updates asynchronously, after promise resolves, we need a promise to be able to get current input value
+     * @example selectDate(new Date()).then(() => {console.log(dp.$el.value)})
+     */
+    selectDate: (date: AirDatepickerDate | AirDatepickerDate[], opts?: {updateTime?: boolean, silent?: boolean}) => Promise<void>
     unselectDate: (date: AirDatepickerDate) => void
     clear: (opts?: {silent?: boolean}) => void
     formatDate: (date: AirDatepickerDate, format: string) => string

--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -462,7 +462,7 @@ export default class Datepicker {
      * @param {object} [params] - extra parameters
      * @param {boolean} [params.updateTime] - should update timepicker's time from passed date
      * @param {boolean} [params.silent] - if true, then onChange event wont be triggered
-     * @return {Promise<unknown>} - returns promise, since input value updates asynchronously, after promise resolves, we need a promise tobe able to get current input value
+     * @return {Promise<void>} - returns promise, since input value updates asynchronously, after promise resolves, we need a promise to be able to get current input value
      * @example selectDate(new Date()).then(() => {console.log(dp.$el.value)})
      */
     selectDate(date, params = {}) {


### PR DESCRIPTION
selectDate returns a Promise<void>
before the type definition file for typescript had it set to void this now fixed and documented