### PR TITLE
Allow dates to be re-enabled in onRenderCell

### DIFF
--- a/src/datepickerCell.js
+++ b/src/datepickerCell.js
@@ -40,6 +40,8 @@ export default class DatepickerCell {
 
         if (this.customData?.disabled) {
             this.dp.disableDate(this.date);
+        } else if (this.customData?.disabled === false) {
+            this.dp.enableDate(this.date);
         }
     }
 


### PR DESCRIPTION
Once a date has been disabled via onRenderCell, returning { disabled: false } will not re-enable the cell.

This PR addresses this issue.

My current implementation means that the onRenderCell consumer must explicitly return disabled: true/false, if they do not (undefined), it will not be updated.