### PR TITLE
BUG : Reset $datepickerOverlay variable  needed for destroy method

### DIFF
--- a/src/datepicker.js
+++ b/src/datepicker.js
@@ -233,7 +233,7 @@ export default class Datepicker {
 
     _removeMobileAttributes() {
         $datepickerOverlay.removeEventListener('click', this._onClickOverlay);
-
+        $datepickerOverlay = '';
         this.$datepicker.classList.remove('-is-mobile-');
 
         if (!this.initialReadonly && this.initialReadonly !== '') {


### PR DESCRIPTION
Need to reset the variable because when using destroy method the overlay is still in memory BUT not attached to the dom. After a new init the overlay does not display.