### PR TITLE
fix: Add button attributes for today and clear presets

### DIFF
--- a/src/buttonPresets.js
+++ b/src/buttonPresets.js
@@ -2,9 +2,15 @@ export default {
     today: {
         content: dp => dp.locale.today,
         onClick: dp => dp.setViewDate(new Date()),
+        attrs: {
+            type: 'button'
+        }
     },
     clear: {
         content: dp => dp.locale.clear,
-        onClick: dp => dp.clear()
+        onClick: dp => dp.clear(),
+        attrs: {
+            type: 'button'
+        }
     }
 };


### PR DESCRIPTION
A HTML button type will be interpret as a submit when the type is ommited.