### PR TITLE
Add Norwegian Nynorsk (nn) locale

### DIFF
--- a/src/locale/nn.js
+++ b/src/locale/nn.js
@@ -1,0 +1,12 @@
+export default {
+    days: ["Søndag", "Måndag", "Tysdag", "Onsdag", "Torsdag", "Fredag", "Laurdag"],
+    daysShort: ["Søn", "Mån", "Tys", "Ons", "Tor", "Fre", "Lau"],
+    daysMin: ["Sø", "Må", "Ty", "On", "To", "Fr", "La"],
+    months: ["Januar", "Februar", "Mars", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Desember"],
+    monthsShort: ["Jan", "Feb", "Mar", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Des"],
+    today: "I dag",
+    clear: "Fjern",
+    dateFormat: "dd.mm.yyyy",
+    timeFormat: "HH:mm",
+    firstDay: 1
+};


### PR DESCRIPTION
Adds a Norwegian **Nynorsk** (`nn`) locale. air-datepicker already ships Bokmål (`nb`); this adds Norway's other official written standard (Nynorsk weekday names, "I dag", etc.).

Disclosure: prepared with AI assistance and reviewed by me as a native Norwegian speaker.